### PR TITLE
Update to Scala 2.13.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG BASE_TAG=latest
 FROM apluslms/grade-java:$BASE_TAG
 
-ARG SCALA_VER=2.12
-ARG SCALA_FVER=2.12.9
+ARG SCALA_VER=2.13
+ARG SCALA_FVER=2.13.1
 ARG SCALA_URL=https://downloads.lightbend.com/scala/$SCALA_FVER/scala-$SCALA_FVER.tgz
 ARG SCALA_DIR=/usr/local/scala
 ENV SCALA_HOME=$SCALA_DIR/scala-$SCALA_FVER
@@ -26,19 +26,19 @@ RUN mkdir -p $SCALA_HOME && cd $SCALA_HOME  \
     org.scala-lang scala-library $SCALA_FVER \
     # compiler
     org.scala-lang scala-compiler $SCALA_FVER \
-    org.scala-lang.modules scala-parser-combinators_$SCALA_VER 1.0.7 \
+    org.scala-lang.modules scala-parser-combinators_$SCALA_VER 1.1.2 \
  && ivy_install -n "grade-scala" -d "$SCALA_DIR/lib" \
     # These go to classpath
     # core libs are repeated, so the deps are resolved to same jars
     org.scala-lang scala-library $SCALA_FVER \
     org.scala-lang scala-compiler $SCALA_FVER \
     # extra libs
-    org.scala-lang.modules scala-swing_$SCALA_VER 2.0.3 \
+    org.scala-lang.modules scala-swing_$SCALA_VER 2.1.1 \
     # for grading
-    org.scalatest scalatest_$SCALA_VER 3.0.5 "default->master,compile,runtime" \
-    org.scalamock scalamock_$SCALA_VER [4.1.0,4.2[ \
-    org.scalastyle scalastyle_$SCALA_VER [1.0.0,1.1[ \
-    com.typesafe.akka akka-actor_$SCALA_VER [2.5.20,2.6[ \
+    org.scalatest scalatest_$SCALA_VER 3.1.1 "default->master,compile,runtime" \
+    org.scalamock scalamock_$SCALA_VER [4.3.0,4.4[ \
+    com.beautiful-scala scalastyle_$SCALA_VER [1.4.0,1.5[ \
+    com.typesafe.akka akka-actor_$SCALA_VER [2.6.1,2.7[ \
  && :
 
 # Add scala utilities


### PR DESCRIPTION
Update to Scala 2.13.1 and JDK 11

Fix FROM

tweak versions and fix base tag

# Description
Original Scalastyle project is no longer maintained, so switched to an actively
supported fork.

Mostly tested with JDK 11, as O1 is moving to it, but JDK 8 should work as well.

# Testing

- [ ] I created new unit tests
- [ ] All unit tests pass
- [X] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [ ] Not relevant
