### PR TITLE
Add support for multiarch container images (amd64/arm64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_TAG=latest
-FROM apluslms/grade-java:$BASE_TAG
+FROM --platform=$TARGETPLATFORM apluslms/grade-java:$BASE_TAG
 
 ARG SCALA_VER=3
 ARG SCALA_FVER=3.3.0

--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -1,5 +1,5 @@
 ARG FULL_TAG=latest
-FROM apluslms/grade-scala:$FULL_TAG
+FROM --platform=$TARGETPLATFORM apluslms/grade-scala:$FULL_TAG
 
 RUN apt_install \
     python3 \

--- a/hooks/build
+++ b/hooks/build
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+docker run --privileged --rm tonistiigi/binfmt --install all
+
+docker buildx create --use default
+
 java_ver=adopt-11
 
 if [ "${DOCKER_TAG#*-}" = "${DOCKER_TAG}" ]; then
@@ -19,11 +23,10 @@ fi
 if [ "$full" != "latest" ]; then
     echo "############################################################"
     echo "### pulling latest image, so layer cache is update."
-    docker pull $DOCKER_REPO:latest || true
+    docker pull $DOCKER_REPO:latest || true
     echo "############################################################"
 fi
 
-: > tags.txt
 for layer in "" "python"; do
     if [ "$layer" ]; then
         tag="$layer-$full"
@@ -38,13 +41,19 @@ for layer in "" "python"; do
     echo "### creating '$DOCKER_REPO:$tag' with '$file'"
     echo "############################################################"
 
-    docker build --build-arg "MAIN_TAG=$main" --build-arg "BASE_TAG=$base" \
-                 --build-arg "FULL_TAG=$full" --build-arg "RESULT_TAG=$tag" \
-                 -t $DOCKER_REPO:$tag -f "$file" .
+    docker buildx build \
+    --build-arg "MAIN_TAG=$main" \
+    --build-arg "BASE_TAG=$base" \
+    --build-arg "FULL_TAG=$full" \
+    --build-arg "RESULT_TAG=$tag" \
+    --push \
+    --platform linux/amd64,linux/arm64 \
+    -t $DOCKER_REPO:$tag \
+    -f "$file" .
+
     res=$?
     if [ $res -ne 0 ]; then
         echo "Building layer $layer returned $res" >&2
         exit $res
     fi
-    echo "$tag" >> tags.txt
 done

--- a/hooks/push
+++ b/hooks/push
@@ -1,7 +1,3 @@
 #!/bin/sh
 
-while read tag; do
-    echo "### Pushing $DOCKER_REPO:$tag"
-    docker push $DOCKER_REPO:$tag
-done < tags.txt
-rm -f tags.txt
+# This hook is empty because the images were pushed to the registry in the build hook


### PR DESCRIPTION
# Description

**What?**

Add support for automatic building of multi-architecture container images (amd64/arm64).

This PR requires that grading-base and grade-java have multi-architecture support first.

**Why?**

Container images built with support for the ARM architecture perform much better on Apple Silicon laptops.

**How?**

A custom build hook is used to build the images for amd64 and arm64.
The images are pushed to Docker Hub in the build hook.

Links about the docker buildx plugin for future reference:
- https://github.com/docker/buildx
- https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
- https://hub.docker.com/r/tonistiigi/binfmt

# Testing

I tested that Docker Hub Automated Builds work as expected.